### PR TITLE
updated to support remote alpha

### DIFF
--- a/libexec/pkenv-list-remote
+++ b/libexec/pkenv-list-remote
@@ -10,4 +10,4 @@ fi
 
 PKENV_REMOTE="${PKENV_REMOTE:-https://releases.hashicorp.com}"
 
-curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(alpha|rc|beta)([0-9]+)*)?" | uniq


### PR DESCRIPTION
```
04:30:14 ubuntu@8d177be1a2a0 ~ → pkenv list
* 1.8.5 (set by /home/ubuntu/.pkenv/version)
04:30:16 ubuntu@8d177be1a2a0 ~ → pkenv list-remote | head
1.9.0-alpha
1.8.6
1.8.5
1.8.4
1.8.3
1.8.2
1.8.1
1.8.0
1.7.10
1.7.9
04:30:25 ubuntu@8d177be1a2a0 ~ → pkenv install latest
[INFO] Installing Packer v1.8.6
[INFO] Downloading release tarball from https://releases.hashicorp.com/packer/1.8.6/packer_1.8.6_linux_arm64.zip
######################################################################################################################## 100.0%
[INFO] Downloading SHA hash file from https://releases.hashicorp.com/packer/1.8.6/packer_1.8.6_SHA256SUMS
pkenv: pkenv-install: [WARN] No keybase install found, skipping OpenPGP signature verification
Archive:  pkenv_download.fHTLIt/packer_1.8.6_linux_arm64.zip
  inflating: /home/ubuntu/.pkenv/versions/1.8.6/packer  
[INFO] Installation of packer v1.8.6 successful
[INFO] Switching to v1.8.6
[INFO] Switching completed
04:30:41 ubuntu@8d177be1a2a0 ~ → pkenv list
* 1.8.6 (set by /home/ubuntu/.pkenv/version)
  1.8.5
04:30:43 ubuntu@8d177be1a2a0 ~ → 
```